### PR TITLE
Adding missing resource string 'euclid_release_version'

### DIFF
--- a/res/values/euclid_strings.xml
+++ b/res/values/euclid_strings.xml
@@ -15,6 +15,7 @@
 
     <string name="euclid_codename_title">euclid Codename</string>
     <string name="euclid_build_version_title">euclid Version</string>
+    <string name="euclid_release_version">euclid Release Version</string>
     <string name="euclid_release_type_title">Release Type</string>
     <string name="device_info_default">Unknown</string>
 


### PR DESCRIPTION
Discussion

This pull request addresses a build error in **firmware_version.xml** caused by a missing resource (**string/euclid_release_version**). The issue prevented the Settings app from building successfully and disrupted the display of firmware information.

Details of the Fix

I added the missing **euclid_release_version** string resource to resolve this issue. The string now allows the Settings app to compile correctly and ensures that firmware information displays as intended.
Points for Reviewers

The current implementation uses a static string for **euclid_release_version**. If there’s an intention to make this value dynamic or if it should be sourced differently (e.g., from a build configuration or API), please advise, and I can make further adjustments.
I aimed to align the formatting and naming conventions to maintain consistency with existing resources. Let me know if there are any specific guidelines or preferences that should be taken into account.
